### PR TITLE
Dump icons

### DIFF
--- a/isubata/webapp/.gitignore
+++ b/isubata/webapp/.gitignore
@@ -1,1 +1,2 @@
 venv/
+public/icons

--- a/isubata/webapp/go/src/isubata/app.go
+++ b/isubata/webapp/go/src/isubata/app.go
@@ -621,6 +621,10 @@ func postAddChannel(c echo.Context) error {
 		fmt.Sprintf("/channel/%v", lastID))
 }
 
+func iconPath(name string) string {
+	return fmt.Sprintf("../public/icons/%s", name)
+}
+
 func postProfile(c echo.Context) error {
 	self, err := ensureLogin(c)
 	if self == nil {
@@ -662,8 +666,7 @@ func postProfile(c echo.Context) error {
 	}
 
 	if avatarName != "" && len(avatarData) > 0 {
-		_, err := db.Exec("INSERT INTO image (name, data) VALUES (?, ?)", avatarName, avatarData)
-		if err != nil {
+		if err := ioutil.WriteFile(iconPath(avatarName), avatarData, 0644); err != nil {
 			return err
 		}
 		_, err = db.Exec("UPDATE user SET avatar_icon = ? WHERE id = ?", avatarName, self.ID)
@@ -704,6 +707,9 @@ func getIcon(c echo.Context) error {
 		mime = "image/gif"
 	default:
 		return echo.ErrNotFound
+	}
+	if err := ioutil.WriteFile(iconPath(name), data, 0644); err != nil {
+		return err
 	}
 	return c.Blob(http.StatusOK, mime, data)
 }


### PR DESCRIPTION
`/icons` が重たいので，ファイルに書き出しておいて nginx でサーブしたい

#### NOTE

- try files で `/icons` に飛ばす
- `POST /profile` と `GET /icons` は nginx と同じサーバで動いている goapp だけに流す

@0gajun cc: @izumin5210 