### PR TITLE
Save memory

### DIFF
--- a/isubata/webapp/go/src/isubata/app.go
+++ b/isubata/webapp/go/src/isubata/app.go
@@ -669,6 +669,7 @@ func postProfile(c echo.Context) error {
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 		if _, err := io.Copy(dst, f); err != nil {
 			return err
 		}


### PR DESCRIPTION
`POST /profile` で画像をメモリに読み込んでからファイルに書き出している．
むだなので `io.Copy` でやりたい．
ファイル名が変わるけどレギュレーション的にはセーフだったはず

cc @0gajun 