### PR TITLE
Stop using prepared statement

### DIFF
--- a/isubata/webapp/go/src/isubata/app.go
+++ b/isubata/webapp/go/src/isubata/app.go
@@ -71,7 +71,7 @@ func init() {
 		redis_url = "redis://localhost:6379"
 	}
 
-	dsn := fmt.Sprintf("%s%s@tcp(%s:%s)/isubata?parseTime=true&loc=Local&charset=utf8mb4",
+	dsn := fmt.Sprintf("%s%s@tcp(%s:%s)/isubata?parseTime=true&loc=Local&charset=utf8mb4&interpolateParams=true",
 		db_user, db_password, db_host, db_port)
 
 	log.Printf("Connecting to db: %q", dsn)


### PR DESCRIPTION
## WHY

> プレースホルダがあるクエリは、デフォルトでは prepared statement を使い捨てにしている (prepare, execute, close の3コマンド) ので、明示的に prepared statement を再利用するコードを書くか、 prepared statement を使わないようにするのがいいです。 最高性能を目指すなら再利用の方がいいですが、改修が簡単なのは prepared statement を使わない方です。 dsn に `interpolateParams=true` を足すだけ！ (僕が実装した機能です。 参考)

http://dsas.blog.klab.org/archives/pixiv-isucon2016-2.html

## WHAT
prepared statementをやめた